### PR TITLE
fix: adding in some loggers to see what is going on in the handler

### DIFF
--- a/src/handlers/index.py
+++ b/src/handlers/index.py
@@ -43,6 +43,23 @@ def kubectl(commands):
 
             logger.info('Running command: %s' % cmd)
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            logger.info(f'Output: {output}')
+
+            decoded_str = output.decode('utf-8')
+            logger.info(f'Decoded string: {decoded_str}')
+
+            # Split the string into individual JSON objects
+            json_objects = decoded_str.strip().split('\n')
+            logger.info(f'JSON objects: {json_objects}')
+
+            # Parse each JSON object and store in a list
+            parsed_json_list = [json.loads(obj) for obj in json_objects]
+            logger.info(f'Parsed JSON list: {parsed_json_list}')
+
+            # Print the list of parsed JSON objects
+            for log in parsed_json_list:
+                logger.info(json.dumps(log), indent=4)
+
         except subprocess.CalledProcessError as exc:
             output = exc.output
             if b'i/o timeout' in output and retry > 0:


### PR DESCRIPTION
Adding in additional loggers to troubleshoot the index handler not properly extracting the byte-type output and converting it to json.